### PR TITLE
Fixing widgets links styles in wordpress

### DIFF
--- a/products-and-docs/widgets/calendar/1.0.0/theme/calendar.css
+++ b/products-and-docs/widgets/calendar/1.0.0/theme/calendar.css
@@ -42,6 +42,9 @@ div[w-theme="calendar"] a:hover,
 div[w-theme="calendar"] a:focus,
 div[w-theme="calendar"] a:active{
     text-decoration: none;
+    -webkit-box-shadow: none !important;
+    -moz-box-shadow: none !important;
+    box-shadow: none !important;
 }
 
 div[w-theme="calendar"] .event-pretended-link {

--- a/products-and-docs/widgets/countdown/1.0.0/theme/fullwidth.css
+++ b/products-and-docs/widgets/countdown/1.0.0/theme/fullwidth.css
@@ -61,6 +61,9 @@ div[w-theme="fullwidth"] a:hover,
 div[w-theme="fullwidth"] a:focus,
 div[w-theme="fullwidth"] a:active {
     text-decoration: none;
+    -webkit-box-shadow: none !important;
+    -moz-box-shadow: none !important;
+    box-shadow: none !important;
 }
 
 div[w-theme="fullwidth"] .event-pretended-link {

--- a/products-and-docs/widgets/countdown/1.0.0/theme/simple_countdown.css
+++ b/products-and-docs/widgets/countdown/1.0.0/theme/simple_countdown.css
@@ -49,6 +49,9 @@ div[w-theme="simple_countdown"] a:hover,
 div[w-theme="simple_countdown"] a:focus,
 div[w-theme="simple_countdown"] a:active{
     text-decoration: none;
+    -webkit-box-shadow: none !important;
+    -moz-box-shadow: none !important;
+    box-shadow: none !important;
 }
 
 div[w-theme="simple_countdown"] .event-pretended-link {

--- a/products-and-docs/widgets/event-discovery/1.0.0/theme/listview.css
+++ b/products-and-docs/widgets/event-discovery/1.0.0/theme/listview.css
@@ -62,6 +62,9 @@ div[w-theme="listview"] a:hover,
 div[w-theme="listview"] a:focus,
 div[w-theme="listview"] a:active{
     text-decoration: none;
+    -webkit-box-shadow: none !important;
+    -moz-box-shadow: none !important;
+    box-shadow: none !important;
 }
 
 div[w-theme="listview"] .event-pretended-link {

--- a/products-and-docs/widgets/event-discovery/1.0.0/theme/listviewthumbnails.css
+++ b/products-and-docs/widgets/event-discovery/1.0.0/theme/listviewthumbnails.css
@@ -62,6 +62,10 @@ div[w-theme="listviewthumbnails"] a:hover,
 div[w-theme="listviewthumbnails"] a:focus,
 div[w-theme="listviewthumbnails"] a:active{
     text-decoration: none;
+    -webkit-box-shadow: none !important;
+    -moz-box-shadow: none !important;
+    box-shadow: none !important;
+
 }
 
 div[w-theme="listviewthumbnails"] .event-pretended-link {

--- a/products-and-docs/widgets/event-discovery/1.0.0/theme/newschool.css
+++ b/products-and-docs/widgets/event-discovery/1.0.0/theme/newschool.css
@@ -39,6 +39,9 @@ div[w-theme="newschool"] a:hover,
 div[w-theme="newschool"] a:focus,
 div[w-theme="newschool"] a:active{
     text-decoration: none;
+    -webkit-box-shadow: none !important;
+    -moz-box-shadow: none !important;
+    box-shadow: none !important;
 }
 
 div[w-theme="newschool"] .event-pretended-link {

--- a/products-and-docs/widgets/event-discovery/1.0.0/theme/oldschool.css
+++ b/products-and-docs/widgets/event-discovery/1.0.0/theme/oldschool.css
@@ -41,6 +41,9 @@ div[w-theme="oldschool"] a:hover,
 div[w-theme="oldschool"] a:focus,
 div[w-theme="oldschool"] a:active{
     text-decoration: none;
+    -webkit-box-shadow: none !important;
+    -moz-box-shadow: none !important;
+    box-shadow: none !important;
 }
 
 div[w-theme="oldschool"] .event-pretended-link {

--- a/products-and-docs/widgets/event-discovery/1.0.0/theme/simple.css
+++ b/products-and-docs/widgets/event-discovery/1.0.0/theme/simple.css
@@ -43,6 +43,9 @@ div[w-theme="simple"] a:hover,
 div[w-theme="simple"] a:focus,
 div[w-theme="simple"] a:active{
     text-decoration: none;
+    -webkit-box-shadow: none !important;
+    -moz-box-shadow: none !important;
+    box-shadow: none !important;
 }
 
 div[w-theme="simple"] .event-pretended-link {

--- a/products-and-docs/widgets/map/1.0.0/theme/simple.css
+++ b/products-and-docs/widgets/map/1.0.0/theme/simple.css
@@ -122,6 +122,9 @@ div[w-theme="simple"] a:hover,
 div[w-theme="simple"] a:focus,
 div[w-theme="simple"] a:active{
 	text-decoration: none;
+    -webkit-box-shadow: none !important;
+    -moz-box-shadow: none !important;
+    box-shadow: none !important;
 }
 
 div[w-theme="simple"] .event-pretended-link {


### PR DESCRIPTION
When widgets are used in WordPress, they links have black border, because of wordpress styling for same classes which is used for widgets.

(cherry picked from commit 38b59dd)